### PR TITLE
Add cargo setup for telemetry memory test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "codeaitest"
+version = "0.1.0"
+edition = "2021"
+
+[target.'cfg(windows)'.dependencies]
+anyhow = "1"
+windows = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Memory"] }
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # CodeAITest
+
+Demonstrates toggling memory protection on Windows using the `windows` crate.
+
+## Usage
+
+Build and run the example on Windows with:
+
+```sh
+cargo run
+```
+
+Running on other platforms prints a message and exits.
+
+Execute the test suite (currently contains no tests) with:
+
+```sh
+cargo test
+```
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,21 @@
 //! - Flips to RX (PAGE_EXECUTE_READ), then back to RW
 //! - Never executes from that region
 
-use anyhow::{bail, Context, Result};
+#[cfg(windows)]
+use anyhow::{bail, Result};
+#[cfg(windows)]
 use core::ffi::c_void;
+#[cfg(windows)]
 use std::{ptr, slice};
+#[cfg(windows)]
 use windows::Win32::Foundation::BOOL;
+#[cfg(windows)]
 use windows::Win32::System::Memory::{
     VirtualAlloc, VirtualFree, VirtualProtect, MEM_COMMIT, MEM_RELEASE, MEM_RESERVE,
-    PAGE_PROTECTION_FLAGS, PAGE_EXECUTE_READ, PAGE_READWRITE,
+    PAGE_EXECUTE_READ, PAGE_PROTECTION_FLAGS, PAGE_READWRITE,
 };
 
+#[cfg(windows)]
 fn main() -> Result<()> {
     unsafe {
         // 1) Reserve+commit 4 KiB, RW
@@ -72,4 +78,9 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() {
+    println!("This example is intended to run on Windows.");
 }


### PR DESCRIPTION
## Summary
- convert standalone Windows memory demo into a Cargo project
- gate Windows-specific code so non-Windows builds compile
- document Cargo usage in README

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895d867fdc08328ac02be24586f4316